### PR TITLE
Fix setting property type for references

### DIFF
--- a/src/main/java/io/wcm/tooling/commons/packmgr/unpack/ContentUnpacker.java
+++ b/src/main/java/io/wcm/tooling/commons/packmgr/unpack/ContentUnpacker.java
@@ -356,11 +356,11 @@ public final class ContentUnpacker {
       else if (StringUtils.startsWith(attribute.getValue(), "{Name}")) {
         collectNamespacePrefixNameArray(namespacePrefixesActuallyUsed, attribute.getValue());
         // alphabetically sort name values
-        attribute.setValue(sortReferenceValues(attribute.getQualifiedName(), attribute.getValue(), PropertyType.NAME));
+        attribute.setValue(sortReferenceValues(attribute.getValue(), PropertyType.NAME));
       }
       else if (StringUtils.startsWith(attribute.getValue(), "{WeakReference}")) {
         // alphabetically sort weak reference values
-        attribute.setValue(sortReferenceValues(attribute.getQualifiedName(), attribute.getValue(), PropertyType.WEAKREFERENCE));
+        attribute.setValue(sortReferenceValues(attribute.getValue(), PropertyType.WEAKREFERENCE));
       }
       if (!excluded) {
         collectNamespacePrefix(namespacePrefixesActuallyUsed, attribute.getNamespacePrefix());
@@ -439,17 +439,16 @@ public final class ContentUnpacker {
 
   /**
    * Sort weak reference values alphabetically to ensure consistent ordering.
-   * @param name Property name
    * @param value Property value
    * @param propertyType Property type from {@link PropertyType}
    * @return Property value with sorted references
    */
-  private String sortReferenceValues(String name, String value, int propertyType) {
+  private String sortReferenceValues(String value, int propertyType) {
     Set<String> refs = new TreeSet<>();
     for (String item : DocViewUtil.parseValues(value)) {
       refs.add(item);
     }
-    return DocViewUtil.formatValues(new ArrayList<>(refs));
+    return DocViewUtil.formatValues(new ArrayList<>(refs), propertyType);
   }
 
 }

--- a/src/main/java/io/wcm/tooling/commons/packmgr/unpack/DocViewUtil.java
+++ b/src/main/java/io/wcm/tooling/commons/packmgr/unpack/DocViewUtil.java
@@ -55,18 +55,28 @@ final class DocViewUtil {
 
   /**
    * Formats multiple values on DocView as a single string.
-   * @param stringValues Values
+   * @param values Values
    * @return DocView values string
    */
-  static String formatValues(List<String> stringValues) {
-    Value[] values = stringValues.stream()
-        .map(value -> new MockValue(value, PropertyType.STRING))
+  static String formatValues(List<String> values) {
+    return formatValues(values, PropertyType.STRING);
+  }
+
+  /**
+   * Formats multiple values on DocView as a single string.
+   * @param values Values
+   * @param propertyType Property type from {@link PropertyType}
+   * @return DocView values string
+   */
+  static String formatValues(List<String> values, int propertyType) {
+    Value[] valueObjects = values.stream()
+        .map(value -> new MockValue(value, propertyType))
         .toArray(size -> new Value[size]);
     try {
-      return DocViewProperty2.fromValues(DUMMY_NAME, values, PropertyType.STRING, true, false, false).formatValue();
+      return DocViewProperty2.fromValues(DUMMY_NAME, valueObjects, propertyType, true, false, false).formatValue();
     }
     catch (RepositoryException ex) {
-      throw new IllegalArgumentException("Unable to format values: " + values, ex);
+      throw new IllegalArgumentException("Unable to format values: " + valueObjects, ex);
     }
   }
 

--- a/src/test/java/io/wcm/tooling/commons/packmgr/unpack/ContentUnpackerTest.java
+++ b/src/test/java/io/wcm/tooling/commons/packmgr/unpack/ContentUnpackerTest.java
@@ -72,6 +72,9 @@ class ContentUnpackerTest {
 
     assertXpathExists("/jcr:root",
         new File(outputDirectory, "jcr_root/content/adaptto/sample/en/.content.xml"));
+
+    assertXpathEvaluatesTo("{Name}[crx:replicate,jcr:write]", "/jcr:root/allow/@rep:privileges",
+        new File(outputDirectory, "jcr_root/content/adaptto/sample/en/_rep_policy.xml"));
   }
 
   @Test


### PR DESCRIPTION
This bug was introduced in #5 within the same release, so no need for a changelog entry.